### PR TITLE
Allow string plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ module.exports = function(grunt) {
 
 };
 ```
-
+--
+### Alternate syntax
+Alternatively, you can pass plugins in by their module name, e.g. 
+```js
+poststylus([
+	'postcss-position',
+	'postcss-hexrgba'
+]);
+```
+the modules will then be automatically required and executed e.g. `'postcss-position'` will become `require('postcss-position')()`
 -- 
 
 ### Custom PostCSS

--- a/index.js
+++ b/index.js
@@ -11,6 +11,24 @@ module.exports = function (plugins) {
     plugins = [];
   }
 
+  // process plugin, if plugin is a string, requires the package that we assume
+  //  that it points to
+  var processPlugin = function(plugin) {
+    if (typeof plugin === 'string') {
+      return require(plugin)();
+    }
+
+    return plugin;
+  };
+
+  // either process each if its an array, or if its singular, process it
+  if (typeof plugins.map !== 'undefined') {
+    // It's an array, process each of them
+    plugins = plugins.map(processPlugin);
+  } else {
+    plugins = processPlugin(plugins);
+  }
+
   // return a stylus function with postcss-processing applied
   return function(style) {
     style = this || style;

--- a/test/mockModule.js
+++ b/test/mockModule.js
@@ -1,0 +1,12 @@
+'use strict';
+var path = require('path'),
+    postcss = require('postcss');
+
+var fake = function() {
+  var mocks = require(path.join(__dirname, 'mocks'));
+  var deps = { postcss: postcss };
+
+  return mocks(deps).plugin;
+};
+
+module.exports = fake;

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -1,0 +1,17 @@
+
+'use strict';
+
+var exports = function(deps) {
+  return {
+    // dummy postcss plugin to test with, finds decleration 'foo:' and removes it
+    plugin: deps.postcss.plugin('test', function (filter) {
+      return function (css) {
+          css.eachDecl(filter || 'foo', function (decl) {
+              decl.removeSelf();
+          });
+      };
+    })
+  };
+};
+
+module.exports = exports;

--- a/test/test.js
+++ b/test/test.js
@@ -11,16 +11,11 @@ var chai = require('chai'),
     parse = require('css-parse');
 
 // path to test input/output files
-var testPath = path.join(__dirname, 'fixtures');
+var testPath = path.join(__dirname, 'fixtures'),
+    mocksPath = path.join(__dirname, 'mocks'),
+    mockDeps = { postcss: postcss };
 
-// dummy postcss plugin to test with, finds decleration 'foo:' and removes it
-var testPlugin = postcss.plugin('test', function (filter) {
-    return function (css) {
-        css.eachDecl(filter || 'foo', function (decl) {
-            decl.removeSelf();
-        });
-    };
-});
+var mocks = require(mocksPath)(mockDeps);
 
 // matching function to test if input stylus = expected output css
 var matchExpected = function(file, plugin, done) {
@@ -52,7 +47,7 @@ var matchExpected = function(file, plugin, done) {
 describe('PostStylus', function() {
 
   it('works', function(done) {
-    return matchExpected('plugin.styl', testPlugin(), done);
+    return matchExpected('plugin.styl', mocks.plugin, done);
   });
 
   it('stays alive when not given plugins', function(done) {
@@ -68,7 +63,7 @@ describe('PostStylus', function() {
     var style = stylus(fs.readFileSync(filename, 'utf8'))
         .set('filename', filename)
         .set('sourcemap', true)
-        .use(poststylus(testPlugin()));
+        .use(poststylus(mocks.plugin()));
 
     // see what gets returned
     return style.render(function(err, css) {

--- a/test/test.js
+++ b/test/test.js
@@ -45,9 +45,22 @@ var matchExpected = function(file, plugin, done) {
 
 // start the tests
 describe('PostStylus', function() {
+  var mockModule;
+
+  before(function() {
+    mockModule = path.join(__dirname, 'mockModule');
+  });
 
   it('works', function(done) {
     return matchExpected('plugin.styl', mocks.plugin, done);
+  });
+
+  it('takes a string and requires it', function(done) {
+    return matchExpected('plugin.styl', mockModule, done);
+  });
+
+  it('takes an array of strings and requires them', function(done) {
+    return matchExpected('plugin.styl', [mockModule], done);
   });
 
   it('stays alive when not given plugins', function(done) {


### PR DESCRIPTION
Allows input parameters to be strings instead of plugin functions. Keeps backwards compatibility with plugin functions so as not to break the API and keep consistency with postcss.

The strings are then assumed to be package names and are required accordingly. e.g. 
```js
poststylus(['postcss-hexrgba']);
``` 
is equivalent to 
```js
poststylus([require('postcss-hexrgba')()]);
``` 

This should make for cleaner passing of plugins e.g. passing in arguments from a CLI