### PR TITLE
Add support for custom warning handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,24 @@ stylus(css).use(poststylus([myPostcss()]))
 
 Refer to the [PostCSS Docs][postcss-link] for more on writing plugins.
 
-__
+--
 
 ### Asynchronous Processing
 Unfortunately the Stylus `end` event that PostStylus uses to pass back post-processed css doesn't accept a callback, so until [this](https://github.com/stylus/stylus/issues/1698) bug is patched upstream PostStylus cannot work with asynchronous PostCSS processing. I would gladly welcome a PR if anyone can think of another way around this issue (see `async` branch for current work on this front).
+
+--
+
+### Warning Handler
+By default, if any of your PostCSS plugins raise a warning it will be displayed using `console.error`. You can override this behaviour by passing a function as the second argument to PostStylus.
+
+```js
+stylus(css).use(poststylus([
+    'autoprefixer',
+    'cssnano'
+], function(message) {
+    console.info(message);
+}))
+```
 
 --
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var postcss = require('postcss'),
     path = require('path'),
     map = require('multi-stage-sourcemap');
 
-module.exports = function (plugins) {
+module.exports = function (plugins, warnFn) {
 
   plugins = plugins || [];
 
@@ -68,7 +68,11 @@ module.exports = function (plugins) {
       }
 
       // Pipe postcss errors to console
-      processed.warnings().forEach(console.error);
+      if (!warnFn || typeof warnFn !== 'function'){
+        warnFn = console.error;
+      }
+
+      processed.warnings().forEach(warnFn);
 
       return processed.css;
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -10,6 +10,14 @@ var exports = function(deps) {
               decl.remove();
           });
       };
+    }),
+    // Dummy postcss plugin to test with, raises a warning if 'shouldWarn' is true
+    warn: deps.postcss.plugin('warn', function (shouldWarn) {
+        return function (css, result) {
+            if (shouldWarn){
+                result.warn('A warning was raised');
+            }
+        };
     })
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -98,4 +98,45 @@ describe('PostStylus', function() {
 
   });
 
+  describe('accepts a warning function', function () {
+    var wasCalled, warnFn, filename, file;
+
+    before(function () {
+      warnFn = function (message) {
+        wasCalled = true;
+      };
+      filename = path.join(testPath, 'plugin.styl');
+      file = fs.readFileSync(filename, 'utf8');
+    });
+
+    beforeEach(function () {
+        wasCalled = false;
+    });
+
+    it('calls the warning function when a warning is raised', function(done) {
+      stylus(file)
+        .use(poststylus(mocks.warn(true), warnFn))
+        .render(function(err) {
+          if (err) {
+            return done(err);
+          }
+
+          should.equal(wasCalled, true);
+          done();
+        });
+    });
+
+    it('does not call the warning function if a warning is not raised', function(done) {
+      stylus(file)
+        .use(poststylus(mocks.warn(false), warnFn))
+        .render(function(err) {
+            if (err) {
+                return done(err);
+            }
+
+            should.equal(wasCalled, false);
+            done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
This will allow the user to perform additional processing when a warning is raised. By default warnings are displayed using `console.error`.